### PR TITLE
Remove personalization_questions_controller

### DIFF
--- a/spec/controllers/personalization_questions_controller_spec.rb
+++ b/spec/controllers/personalization_questions_controller_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe PersonalizationQuestionsController, :type => :controller do
-
-end


### PR DESCRIPTION
Remove errant `spec/controllers/personalization_questions_controller_spec.rb`file.  The correct file `spec/controllers/api/v1/personalization_questions_controller_spec.rb` exists.

Closes #33 